### PR TITLE
Improved libcangjie2_cli with command line options

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -1,6 +1,7 @@
 #include <getopt.h>
 #include <stdio.h>
 #include <string.h>
+#include <libgen.h>
 
 #include <cangjie.h>
 
@@ -14,7 +15,7 @@ typedef enum CangjieCliMode {
 
 
 int usage(const char *progname) {
-    printf("Usage: %s [OPTIONS]... CODE\n", progname);
+    printf("Usage: %s [OPTIONS]... CODE\n", basename(progname));
     printf("A CLI interface of libcangjie2 cangjie code query\n\n");
     printf("-f, --filter=FILTER1,FILTER2...  specify the filters used in the query\n");
     printf("                                 default: big5,hkscs\n");


### PR DESCRIPTION
The CLI tool `libcangjie2_cli` is improved to accept the following options:

```
-f, --with-filter=FILTER1,FILTER2...  specify the filters used in the query
                                      default: big5,hkscs
                                      acceptable values:
                                        big5, hkscs, punctuation, chinese,
                                        zhuyin, kanji, katakana, symbols
-m, --mode=MODE                       specify the mode of query
                                      default: code
                                      acceptable values:
                                        code, shortcode, radical
-u, --use-cj-version=VERSION          specify the version of Cangjie used
                                      default: 3
                                      acceptable values: 3, 5
-h, --help                            print this help message and leave
```

These changes should be sufficient to resolve #1.
