### PR TITLE
Input code handling

### DIFF
--- a/src/cangjie.c
+++ b/src/cangjie.c
@@ -300,6 +300,10 @@ int cangjie_get_characters_by_shortcode(Cangjie          *cj,
     sqlite3_stmt *stmt;
     int ret;
 
+    if (strlen(input_code) > 1) {
+        return CANGJIE_INVALID;
+    }
+
     char *query = sqlite3_mprintf(cj->shortcode_query, 0, input_code);
     if (query == NULL) {
         return CANGJIE_NOMEM;


### PR DESCRIPTION
This brings in two changes related to how we process the input codes:
- validate the input code a minimum, to avoid future issues
- use the GLOB operator instead of the LIKE operator, which removes the need to transform the `*` wildcard into the `%` one.
