### PR TITLE
Fixed CLI option error

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -135,7 +135,7 @@ int main(int argc, char **argv) {
                     return -1;
                 }
                 break;
-            case 'u':
+            case 'C':
                 if (*optarg == '3') {
                     opt_cj_version = CANGJIE_VERSION_3;
                 } else if (*optarg == '5') {


### PR DESCRIPTION
The options for --use-cj-version (-u) should have been renamed to
--cj-version (-C) in pull request #13. This CLI option renaming,
although implemented in usage() and getopt_log(), was not
implemented in the case switch statement.

This commit is a fix to that.
