### PR TITLE
Various changes to the benchmark tool

### DIFF
--- a/src/bench.c
+++ b/src/bench.c
@@ -1,3 +1,22 @@
+/* Copyright (c) 2013 - The libcangjie authors.
+ *
+ * This file is part of libcangjie.
+ *
+ * libcangjie is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libcangjie is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with libcangjie.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>


### PR DESCRIPTION
This adds the missing copyright header (thanks @anthonywong), makes the tool actually benchmark queries (what a stupid mistake ^_^), etc...
