### PR TITLE
Fix issue #73

### DIFF
--- a/src/cangjie.c
+++ b/src/cangjie.c
@@ -145,7 +145,7 @@ int cangjie_get_filter_query(Cangjie *cj, char **query) {
 
 int cangjie_new(Cangjie        **cj,
                 CangjieVersion   version,
-                CangjieFilter    filter_flags) {
+                unsigned int     filter_flags) {
     char *filter_query;
     int ret;
     char *database_path;

--- a/src/cangjie.h
+++ b/src/cangjie.h
@@ -60,7 +60,7 @@ typedef struct Cangjie {
 
 CANGJIE_EXTERN int cangjie_new(Cangjie        **cj,
                                CangjieVersion   version,
-                               CangjieFilter    filter_flags);
+                               unsigned int     filter_flags);
 
 CANGJIE_EXTERN int cangjie_get_characters(Cangjie          *cj,
                                           char             *code,


### PR DESCRIPTION
First commit just adds some whitespace.

Second commit is the actual issue. We were doing something completely harmless in C, but invalid in C++.

Big thanks to @cfergeau for his help explaining this to me. :smile: 
