### PR TITLE
ci: Pretty print the OS from an existing file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,5 @@ before_install:
   - docker pull "cangjians/build-essential:${OS}"
   - docker build --build-arg OS=${OS} --tag "cangjians/libcangjie:${OS}" .
 script:
+  - docker run --rm "cangjians/libcangjie:${OS}" bash -c '. /usr/lib/os-release && echo $PRETTY_NAME'
   - docker run --rm "cangjians/libcangjie:${OS}" make distcheck

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,5 @@ WORKDIR /usr/local/src/libcangjie
 COPY "." "./"
 
 # build the library
-RUN echo -e "\n\nOS=$(cat /var/version)\n---------------\n" && \
-  ./autogen.sh --prefix=/usr && \
+RUN ./autogen.sh --prefix=/usr && \
   make && make install


### PR DESCRIPTION
The CI already shows us the content of the $OS veriable (which is what we put in the /var/version file), for example:

    $ docker pull "cangjians/build-essential:${OS}"
    ubuntu-lts: Pulling from cangjians/build-essential

    Status: Downloaded newer image for cangjians/build-essential:ubuntu-lts

So we don't need the /var/version file at all.

However, knowing this is `ubuntu-devel` is great, but in a few months, will we remember what actual version was the Ubuntu LTS?

We can get a more interesting output from the /usr/lib/os-release file, which is a cross-distro standard:

    $ docker run --rm "cangjians/libcangjie:${OS}" bash -c '. /usr/lib/os-release && echo $PRETTY_NAME'
    Ubuntu 16.04.3 LTS